### PR TITLE
Fix official-sounding message

### DIFF
--- a/src/main/resources/quilt.mod.json
+++ b/src/main/resources/quilt.mod.json
@@ -9,7 +9,7 @@
             "description": "The mod-loader that cares and works on Forge.",
             "contributors": {
                 "PillowMC": "Owner",
-                "QuiltMC": "Quilt Owner"
+                "QuiltMC (credits only)": "Quilt Owner"
             },
             "contact": {
                 "homepage": "https://pillowmc.github.io",


### PR DESCRIPTION
Just leaving it as QuiltMC makes it look like it's an official product of QuiltMC, which could be an issue. I have added a `(credits only)` onto the end, which in certain launchers such as PolyMC, makes this look a lot better